### PR TITLE
fix: use raw script tag for Ahrefs Analytics

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
@@ -28,11 +27,8 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <head>
-        <Script
-          src="https://analytics.ahrefs.com/analytics.js"
-          data-key="b6anr10SUmvcCXeeqSt/yQ"
-          strategy="afterInteractive"
-        />
+        <link rel="preload" href="https://analytics.ahrefs.com/analytics.js" as="script"/>
+        <script src="https://analytics.ahrefs.com/analytics.js" data-key="b6anr10SUmvcCXeeqSt/yQ" async></script>
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}


### PR DESCRIPTION
Replace Next.js Script component with raw script tag to preserve data attributes and add preload link for optimization.