### PR TITLE
refactor: convert tags to English and unify tag naming conventions

### DIFF
--- a/src/content/README.md
+++ b/src/content/README.md
@@ -111,9 +111,52 @@ content/
 
 ### タグの命名規則
 
-- 技術スタックは正式名称を使用（例: "Next.js", "TypeScript"）
-- カテゴリータグは日本語可（例: "チュートリアル", "ベストプラクティス"）
-- タグは先頭を大文字に統一
+技術スタックとカテゴリー、両方のタグを英語で記述します：
+
+1. 技術スタック
+   - 正式名称をそのまま使用（例: "Next.js", "TypeScript", "Python"）
+   - 大文字小文字は正式な表記に従う
+
+2. カテゴリータグ
+   - すべて英語で記述
+   - 複数単語の場合はスペースで区切る（例: "Web Development", "Best Practice"）
+   - 先頭の単語を大文字にする
+
+例:
+```json
+{
+  "tags": [
+    "Next.js",          // 技術スタック（正式名称）
+    "TypeScript",       // 技術スタック（正式名称）
+    "Web Development",  // カテゴリー
+    "Frontend",         // カテゴリー
+    "Tutorial"          // カテゴリー
+  ]
+}
+```
+
+推奨されるカテゴリータグ:
+- "Tutorial" - チュートリアル
+- "Best Practice" - ベストプラクティス
+- "Getting Started" - 入門ガイド
+- "Guide" - 解説記事
+- "Practice" - 実践的な内容
+- "Case Study" - 事例研究
+- "Architecture" - アーキテクチャ設計
+- "Performance" - パフォーマンス
+- "Security" - セキュリティ
+- "Frontend" - フロントエンド開発
+- "Backend" - バックエンド開発
+- "Web Development" - Web開発全般
+- "API" - API関連
+- "Database" - データベース
+- "DevOps" - 開発運用
+- "Testing" - テスト関連
+- "Mobile" - モバイル開発
+- "Education" - 教育
+- "Learning Design" - 学習設計
+- "Video Processing" - 動画処理
+- "Streaming" - ストリーミング
 
 ## 記事の作成ガイドライン
 

--- a/src/content/posts/downloading-videos-with-ffmpeg-m3u8/index.json
+++ b/src/content/posts/downloading-videos-with-ffmpeg-m3u8/index.json
@@ -3,7 +3,7 @@
     "title": "FFmpegでm3u8形式の動画をダウンロードする実践ガイド",
     "description": "FFmpegを使用してm3u8形式の動画をダウンロードする方法を詳しく解説します。基本的なコマンドから認証が必要なケース、エラー対応まで、実践的なテクニックを網羅的に紹介します。",
     "publishedAt": "2024-01-31T00:00:00.000Z",
-    "tags": ["FFmpeg", "m3u8", "HLS", "動画処理", "ストリーミング"],
+    "tags": ["FFmpeg", "m3u8", "HLS", "Video Processing", "Streaming"],
     "author": {
       "name": "tech.jugoya.ai",
       "avatar": "/images/avatars/jugoya.png"

--- a/src/content/posts/evolving-graphql-2024/index.json
+++ b/src/content/posts/evolving-graphql-2024/index.json
@@ -3,7 +3,7 @@
     "title": "進化するGraphQL: 2024年におけるトレンドと実践的アプローチ",
     "description": "GraphQLの基本から最新の実践的な使用パターンまで、詳しく解説します。従来のREST APIとの比較、N+1問題への対処、Distributed GraphQLなど、実装時の重要なポイントを網羅的に紹介します。",
     "publishedAt": "2024-12-31T00:00:00.000Z",
-    "tags": ["GraphQL", "API", "Web開発", "バックエンド", "フロントエンド"],
+    "tags": ["GraphQL", "API", "Web Development", "Backend", "Frontend"],
     "author": {
       "name": "tech.jugoya.ai",
       "avatar": "/images/avatars/jugoya.png"

--- a/src/content/posts/getting-started-with-nextjs.json
+++ b/src/content/posts/getting-started-with-nextjs.json
@@ -4,7 +4,7 @@
     "description": "Next.jsを使用してブログを構築する方法を解説します。App RouterやTypeScriptの活用方法も含めて説明します。",
     "publishedAt": "2024-01-01T00:00:00.000Z",
     "updatedAt": "2024-01-02T00:00:00.000Z",
-    "tags": ["Next.js", "TypeScript", "React"]
+    "tags": ["Next.js", "TypeScript", "React", "Frontend", "Web Development"]
   },
   "blocks": [
     {

--- a/src/content/posts/typescript-best-practices.json
+++ b/src/content/posts/typescript-best-practices.json
@@ -4,7 +4,7 @@
     "description": "TypeScriptを効果的に活用するためのベストプラクティスを紹介します。型の活用からプロジェクト構成まで、実践的なTipsをお届けします。",
     "publishedAt": "2024-01-15T00:00:00.000Z",
     "updatedAt": "2024-01-16T00:00:00.000Z",
-    "tags": ["TypeScript", "JavaScript", "Programming"]
+    "tags": ["TypeScript", "JavaScript", "Programming", "Best Practice"]
   },
   "blocks": [
     {

--- a/src/content/posts/understanding-kahoot-2024/index.json
+++ b/src/content/posts/understanding-kahoot-2024/index.json
@@ -3,7 +3,7 @@
     "title": "Kahoot!完全解説2024 - 93の研究が実証する教育効果と実践テクニック",
     "description": "Kahoot!の効果が93の学術研究で実証されました。最新機能と研究に基づく活用法を詳しく解説し、具体的な設定例とベストプラクティスを紹介します。",
     "publishedAt": "2024-01-30T00:00:00.000Z",
-    "tags": ["EdTech", "教育", "Kahoot", "学習設計", "Python"]
+    "tags": ["EdTech", "Education", "Kahoot", "Learning Design", "Python"]
   },
   "blocks": [
     {
@@ -33,4 +33,3 @@
     }
   ]
 }
-

--- a/src/content/posts/understanding-m3u8-and-ffmpeg/index.json
+++ b/src/content/posts/understanding-m3u8-and-ffmpeg/index.json
@@ -3,7 +3,7 @@
     "title": "実践で学ぶm3u8/HLSストリーミング - FFmpegによる高度な動画配信の実装",
     "description": "m3u8ファイルはHTTP Live Streaming（HLS）で使用される重要なプレイリストファイルです。本記事では、m3u8の基本概念から、アダプティブストリーミングでの役割、さらにFFmpegを使った変換・ダウンロード・作成まで、実践的な活用方法を具体的なコマンド例とともに解説します。",
     "publishedAt": "2024-01-01T00:00:00.000Z",
-    "tags": ["m3u8", "ffmpeg", "video", "streaming", "HLS"],
+    "tags": ["m3u8", "FFmpeg", "Video Processing", "Streaming", "HLS"],
     "author": "yonaka"
   },
   "blocks": [


### PR DESCRIPTION
- Update tag naming rules in README.md
- Convert Japanese category tags to English
- Add comprehensive list of recommended category tags
- Unify technical stack tag capitalization (e.g. ffmpeg -> FFmpeg)
- Add missing category tags to some posts