### PR TITLE
fix: Use formatTagForUrl for consistent tag URL generation in sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
 import { getAllPosts } from '../lib/blog'
+import { formatTagForUrl } from '../lib/tags'
 
 /**
  * サイトマップを生成する
@@ -40,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
     // タグページのURL
     ...Array.from(new Set(posts.flatMap((post) => post.meta.tags))).map((tag) => ({
-      url: `${baseUrl}/tags/${encodeURIComponent(tag.toLowerCase())}`,
+      url: `${baseUrl}/tags/${formatTagForUrl(tag)}`,
       lastModified: new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.4,

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: Props) {
 export async function generateStaticParams() {
   const tags = await getAllTags();
   return tags.map(tag => ({ 
-    tag: encodeURIComponent(formatTagForUrl(tag))
+    tag: formatTagForUrl(tag)
   }));
 }
 
@@ -90,7 +90,7 @@ export default async function TagPage({ params }: Props) {
                   {post.meta.tags.map(t => (
                     <Link
                       key={t}
-                      href={`/tags/${encodeURIComponent(formatTagForUrl(t))}`}
+                      href={`/tags/${formatTagForUrl(t)}`}
                       className={`
                         text-sm px-2 py-1 rounded-full
                         ${t === originalCaseTag

--- a/src/lib/middleware/tags.ts
+++ b/src/lib/middleware/tags.ts
@@ -1,0 +1,37 @@
+// src/lib/middleware/tags.ts
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { formatTagForUrl } from '../tags'
+
+/**
+ * タグページのURLを正規化する
+ * - /tags/{tag} 形式のパスを処理
+ * - 大文字や空白を含むタグを正規化
+ * - URL規格に沿った形式に変換
+ * 
+ * @example
+ * - /tags/Streaming -> /tags/streaming
+ * - /tags/Web%20Development -> /tags/web-development
+ */
+export function normalizeTagUrl(request: NextRequest): NextResponse | null {
+  if (!request.nextUrl.pathname.startsWith('/tags/')) {
+    return null
+  }
+
+  const parts = request.nextUrl.pathname.split('/')
+  if (parts.length !== 3 || !parts[2]) {
+    return null
+  }
+
+  // URLエンコードされた状態を元に戻してから処理
+  const tag = decodeURIComponent(parts[2])
+  const normalizedTag = formatTagForUrl(tag)
+  
+  if (normalizedTag === parts[2]) {
+    return null
+  }
+
+  const newUrl = new URL(request.url)
+  newUrl.pathname = `/tags/${normalizedTag}`
+  return NextResponse.redirect(newUrl, 308) // 308 Permanent Redirect
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -3,12 +3,15 @@
  * - 小文字に変換
  * - 空白をハイフンに置換
  * - 前後の空白を削除
+ * - URLエンコード
  */
 export function formatTagForUrl(tag: string): string {
-  return tag
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-');
+  return encodeURIComponent(
+    tag
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, '-')
+  );
 }
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { createAccessLog, logAccess } from './lib/middleware/logger'
+import { normalizeTagUrl } from './lib/middleware/tags'
 
 export function middleware(request: NextRequest) {
   const log = createAccessLog(request)
   logAccess(log)
+
+  // タグページのURL正規化
+  const tagRedirect = normalizeTagUrl(request)
+  if (tagRedirect) {
+    return tagRedirect
+  }
 
   return NextResponse.next()
 }


### PR DESCRIPTION
Use the formatTagForUrl function from lib/tags instead of direct toLowerCase() to ensure consistent tag URL generation across the application. This fixes the duplicate tag URLs issue where both "/tags/Streaming" and "/tags/streaming" were being generated.