### PR TITLE
feat: implement clickable tags in post pages

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,9 @@ import { getPost, getAllPosts } from '@/lib/blog';
 import BlockRenderer from '@/components/blog/blocks/BlockRenderer';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { generateBlogPostMetadata, generateBlogPostJsonLd } from '@/types/metadata';
+import { formatTagForUrl } from '@/lib/tags';
 
 // ビルド時に生成される記事のみを許可
 export const dynamicParams = false;
@@ -88,12 +90,13 @@ export default async function BlogPostPage({
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
             <div className="flex flex-wrap gap-2">
               {post.meta.tags.map(tag => (
-                <span 
-                  key={tag} 
-                  className="px-2 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200 transition-colors"
+                <Link
+                  key={tag}
+                  href={`/tags/${formatTagForUrl(tag)}`}
+                  className="text-sm px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
                 >
                   {tag}
-                </span>
+                </Link>
               ))}
             </div>
             <div className="text-sm text-gray-500 space-y-1">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,9 @@
 import { type FC } from 'react';
-import Link from 'next/link';
 import { getAllPosts } from '@/lib/blog';
 import type { Metadata } from 'next';
 import { siteConfig } from '@/config/site';
 import { defaultMetadata } from '@/types/metadata';
+import PostPreview from '@/components/blog/PostPreview';
 
 export const metadata: Metadata = {
   ...defaultMetadata,
@@ -28,28 +28,7 @@ const BlogPage: FC = async () => {
       <h1 className="text-3xl font-bold mb-8">Blog Posts</h1>
       <div className="grid gap-6">
         {posts.map((post) => (
-          <Link 
-            key={post.slug} 
-            href={`/blog/${post.slug}`}
-            className="block"
-          >
-            <article className="p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow">
-              <h2 className="text-2xl font-semibold mb-2">{post.meta.title}</h2>
-              <p className="text-gray-600 mb-4">{post.meta.description}</p>
-              <div className="flex items-center justify-between">
-                <div className="flex gap-2">
-                  {post.meta.tags.map(tag => (
-                    <span key={`${post.slug}-${tag}`} className="px-2 py-1 bg-gray-100 text-sm rounded">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-                <time className="text-sm text-gray-500" dateTime={post.meta.publishedAt}>
-                  {new Date(post.meta.publishedAt).toLocaleDateString('ja-JP')}
-                </time>
-              </div>
-            </article>
-          </Link>
+          <PostPreview key={post.slug} post={post} />
         ))}
       </div>
     </div>

--- a/src/components/blog/PostPreview.tsx
+++ b/src/components/blog/PostPreview.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { formatTagForUrl } from '@/lib/tags';
+import { type PostWithSlug } from '@/lib/blog';
+
+export default function PostPreview({ post }: { post: PostWithSlug }) {
+  return (
+    <article className="p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow">
+      <Link 
+        href={`/blog/${post.slug}`}
+        className="block mb-4"
+      >
+        <h2 className="text-2xl font-semibold mb-2">{post.meta.title}</h2>
+        <p className="text-gray-600">{post.meta.description}</p>
+      </Link>
+      <div className="flex items-center justify-between">
+        <div className="flex gap-2">
+          {post.meta.tags.map(tag => (
+            <Link
+              key={`${post.slug}-${tag}`}
+              href={`/tags/${formatTagForUrl(tag)}`}
+              className="text-sm px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+            >
+              {tag}
+            </Link>
+          ))}
+        </div>
+        <time className="text-sm text-gray-500" dateTime={post.meta.publishedAt}>
+          {new Date(post.meta.publishedAt).toLocaleDateString('ja-JP')}
+        </time>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
- Convert tags to clickable links in post pages
- Add PostPreview component for list page
- Fix dark mode support in tag styling
- Keep the original design while making tags interactive